### PR TITLE
[CVE-2021-44228] bump log4j version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,1 +1,1 @@
-{:deps {org.apache.logging.log4j/log4j-core {:mvn/version "2.14.1"}}}
+{:deps {org.apache.logging.log4j/log4j-core {:mvn/version "2.15.0"}}}


### PR DESCRIPTION
hopefully you don't mind this pr. our builds that used `build-clj` started failing because we blocked downloads for known bad versions of `log4j`.