### PR TITLE
Add GitHub Actions to deploy releases to clojars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release Version
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: '1.10.3.1053'
+      - name: Cache All The Things
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.clojure
+            ~/.cpcache
+          key: ${{ runner.os }}-${{ hashFiles('**/deps.edn') }}
+      - name: Build jar
+        run: clojure -T:build jar :snapshot false
+      - name: Deploy Release
+        run: clojure -T:build deploy :snapshot false
+        env:
+          CLOJARS_PASSWORD: ${{secrets.DEPLOY_TOKEN}}
+          CLOJARS_USERNAME: ${{secrets.DEPLOY_USERNAME}}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,63 @@
+name: Snapshot
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build-and-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: '1.10.3.1053'
+      - name: Cache All The Things
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.clojure
+            ~/.cpcache
+          key: ${{ runner.os }}-${{ hashFiles('**/deps.edn') }}
+      - name: Build Jar
+        run: clojure -T:build jar :snapshot true
+      - name: Deploy Snapshot
+        run: clojure -T:build deploy :snapshot true
+        env:
+          CLOJARS_PASSWORD: ${{secrets.DEPLOY_TOKEN}}
+          CLOJARS_USERNAME: ${{secrets.DEPLOY_USERNAME}}
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '8', '14', '17' ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+      - name: Clojure CLI
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: '1.10.3.1053'
+      - name: Cache All The Things
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.clojure
+            ~/.cpcache
+          key: ${{ runner.os }}-${{ hashFiles('**/deps.edn') }}
+      - name: Build jar
+        run: clojure -T:build jar

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,19 @@
+(ns build
+  (:require [org.corfield.build :as bb]))
+
+(def lib 'com.github.seancorfield/build-uber-log4j2-handler)
+(def version "0.1.5")
+(defn get-version [opts]
+  (str version (when (:snapshot opts) "-SNAPSHOT")))
+
+(defn jar [opts]
+  (-> opts
+      (assoc :lib lib :version (get-version opts))
+      bb/clean
+      (assoc :src-pom "template/pom.xml")
+      bb/jar))
+
+(defn deploy "Deploy the JAR to Clojars." [opts]
+  (-> opts
+      (assoc :lib lib :version (get-version opts))
+      bb/deploy))

--- a/deps.edn
+++ b/deps.edn
@@ -1,1 +1,5 @@
-{:deps {org.apache.logging.log4j/log4j-core {:mvn/version "2.17.1"}}}
+{:deps {org.apache.logging.log4j/log4j-core {:mvn/version "2.17.1"}}
+ :aliases
+ {:build {:deps {io.github.seancorfield/build-clj
+                 {:git/tag "v0.8.0" :git/sha "9bd8b8a"}}
+          :ns-default build}}}

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>build-uber-log4j2-handler</name>
+  <description>A conflict handler for log4j2 plugins cache files for the tools.build uber task.</description>
+  <url>https://github.com/seancorfield/build-uber-log4j2-handler</url>
+  <scm>
+    <url>https://github.com/seancorfield/build-uber-log4j2-handler</url>
+    <connection>scm:git:git://github.com/seancorfield/build-uber-log4j2-handler.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/seancorfield/build-uber-log4j2-handler.git</developerConnection>
+  </scm>
+</project>


### PR DESCRIPTION
This makes it easier to use as a transitive dependency, because maven deps can't depend on git deps.

The code is nearly identical to honeysql's, except that tests are not run (because there aren't any). Requires `${{secrets.DEPLOY_TOKEN}}` and `${{secrets.DEPLOY_USERNAME}}` to be set.